### PR TITLE
New Transparency/Highlight Status System

### DIFF
--- a/Assets/Prefabs/Status/Utils.meta
+++ b/Assets/Prefabs/Status/Utils.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 36ebc56e1944b404cae3a3e4bed002ae
+folderAsset: yes
+timeCreated: 1507972643
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Status/Utils/HighlightStatus.prefab
+++ b/Assets/Prefabs/Status/Utils/HighlightStatus.prefab
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1157385417311886}
+  m_IsPrefabParent: 1
+--- !u!1 &1157385417311886
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4866274046843648}
+  - component: {fileID: 114479238163075520}
+  m_Layer: 0
+  m_Name: HighlightStatus
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4866274046843648
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1157385417311886}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114479238163075520
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1157385417311886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ca4db7c517beb2843b072c56f8b2d4ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Status/Utils/HighlightStatus.prefab.meta
+++ b/Assets/Prefabs/Status/Utils/HighlightStatus.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 02146c516cd3b2e49a9bff2752a772a1
+timeCreated: 1507972799
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Status/Utils/TransparentStatus.prefab
+++ b/Assets/Prefabs/Status/Utils/TransparentStatus.prefab
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1401128514481788}
+  m_IsPrefabParent: 1
+--- !u!1 &1401128514481788
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4627931322173220}
+  - component: {fileID: 114416426956639682}
+  m_Layer: 0
+  m_Name: TransparentStatus
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4627931322173220
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1401128514481788}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114416426956639682
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1401128514481788}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 50c3c7e75603ffe4fa0ab432328d02ce, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Status/Utils/TransparentStatus.prefab.meta
+++ b/Assets/Prefabs/Status/Utils/TransparentStatus.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 4fb2b4ab28f910942adefefd5abcd1e5
+timeCreated: 1507972801
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Classes.meta
+++ b/Assets/Scripts/Classes.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9cf88ef3728cec14ebbdada23a5d5b65
+folderAsset: yes
+timeCreated: 1506183270
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Classes/Warrior.meta
+++ b/Assets/Scripts/Classes/Warrior.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d8a20cae692f07341877e60bbe556618
+folderAsset: yes
+timeCreated: 1507314288
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Classes/Warrior/Passive.meta
+++ b/Assets/Scripts/Classes/Warrior/Passive.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 4deb0a46eba697e4b810bfecc5d6c617
+folderAsset: yes
+timeCreated: 1507314309
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Classes/Warrior/ScriptsOnPrefabs.meta
+++ b/Assets/Scripts/Classes/Warrior/ScriptsOnPrefabs.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 934ffca1b515ab548980a3a5643ee909
+folderAsset: yes
+timeCreated: 1507314309
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Entities/EntityLivingBase.cs
+++ b/Assets/Scripts/Entities/EntityLivingBase.cs
@@ -93,11 +93,16 @@ public abstract class EntityLivingBase : MonoBehaviour
 
     /** EntityDies protected method.
      * This method is called when HP reaches 0.
-     * When launched, this method should launch the death animation of the element.
+     * When launched, this method should launch the death animation of the element and clear all Status present on the entity.
      * Then it starts the coroutine DespawnEntity.
      **/
     protected void EntityDies()
     {
+		IStatus[] status = GetComponentsInChildren<IStatus>();
+		foreach(IStatus s in status) 
+		{
+			s.DestroyStatus();
+		}
         /// TODO : We need to add HERE the death Animation.
         StartCoroutine(DespawnEntity());
     }

--- a/Assets/Scripts/Spells.meta
+++ b/Assets/Scripts/Spells.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 18e0385d40e6b414aa5f6ca8f1ee237b
+folderAsset: yes
+timeCreated: 1507972285
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Status/BASE_STATUS/StatusBase.cs
+++ b/Assets/Scripts/Status/BASE_STATUS/StatusBase.cs
@@ -9,20 +9,26 @@ using UnityEngine;
  **/
 public abstract class StatusBase : MonoBehaviour, IStatus
 {
-
-    protected int maxDuration;
+    protected float maxDuration;
     protected float tickInterval;
     protected float delay;
+    protected bool isTickable = true;
 
     /** Start protected virtual void
      * The method is here to launch the method OnStatusApplied.
-     * Then, it lanches an InvokeRepeating on StatusTickBehaviour to make the status tick every tickInterval;
+     * Then, it lanches an InvokeRepeating on StatusTickBehaviour to make the status tick every tickInterval.
+	 * Please note that, by default, a Status is considered as tickable.
      * Finally, it lanches an Invoke on DestroyStatus that will occurs in maxDuration seconds.
      **/
     protected virtual void Start()
     {
         OnStatusApplied();
-        InvokeRepeating("StatusTickBehaviour", delay, tickInterval);
+
+        if (isTickable)
+        {
+            InvokeRepeating("StatusTickBehaviour", delay, tickInterval);
+        }
+
         Invoke("DestroyStatus", maxDuration);
     }
 
@@ -46,10 +52,14 @@ public abstract class StatusBase : MonoBehaviour, IStatus
     public virtual void ResetStatus()
     {
         OnStatusApplied();
-        CancelInvoke("StatusTickBehaviour");
         CancelInvoke("DestroyStatus");
-        InvokeRepeating("StatusTickBehaviour", delay, tickInterval);
         Invoke("DestroyStatus", maxDuration);
+
+        if (isTickable)
+        {
+            CancelInvoke("StatusTickBehaviour");
+            InvokeRepeating("StatusTickBehaviour", delay, tickInterval);
+        }
     }
 
     /** DestroyStatus public virtual void

--- a/Assets/Scripts/Status/Utils.meta
+++ b/Assets/Scripts/Status/Utils.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c05c574432c56844e99987640c18e880
+folderAsset: yes
+timeCreated: 1507972359
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Status/Utils/HighlightStatus.cs
+++ b/Assets/Scripts/Status/Utils/HighlightStatus.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class HighlightStatus : StatusBase
+{
+    private Shader _oldShader;
+    private Renderer _objectRenderer;
+
+    public override void OnStatusApplied()
+    {
+        isTickable = false;
+        maxDuration = 0.05f;
+        tickInterval = 0f;
+        delay = 0f;
+
+        _objectRenderer = GetComponentInParent<Renderer>();
+        if (_objectRenderer == null)
+            base.DestroyStatus();
+
+        if (_oldShader == null)
+        {
+            _oldShader = _objectRenderer.material.shader;
+            _objectRenderer.material.shader = Shader.Find("Outlined/Diffuse");
+        }
+    }
+
+    public override void StatusTickBehaviour() { }
+
+    public override void DestroyStatus()
+    {
+        _objectRenderer.material.shader = _oldShader;
+        base.DestroyStatus();
+    }
+}

--- a/Assets/Scripts/Status/Utils/HighlightStatus.cs.meta
+++ b/Assets/Scripts/Status/Utils/HighlightStatus.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ca4db7c517beb2843b072c56f8b2d4ba
+timeCreated: 1507972481
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Status/Utils/TransparentStatus.cs
+++ b/Assets/Scripts/Status/Utils/TransparentStatus.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TransparentStatus : StatusBase
+{
+
+    private const float _targetTransparancy = 0.2f;
+    private Shader _oldShader;
+    private Color _oldColor;
+
+    private Renderer _objectRenderer;
+    private Color _newColor;
+    private float _transparency;
+
+    public override void OnStatusApplied()
+    {
+        isTickable = false;
+        maxDuration = 0.05f;
+        tickInterval = 0f;
+        delay = 0f;
+
+        _objectRenderer = GetComponentInParent<Renderer>();
+        if (_objectRenderer == null)
+            base.DestroyStatus();
+
+        if (_oldShader == null)
+        {
+            _transparency = _targetTransparancy;
+            _oldShader = _objectRenderer.material.shader;
+            _oldColor = _objectRenderer.material.color;
+            _objectRenderer.material.shader = Shader.Find("Legacy Shaders/Transparent/Diffuse");
+
+            _newColor = _objectRenderer.material.color;
+            _newColor.a = _transparency;
+            _objectRenderer.material.color = _newColor;
+        }
+    }
+
+    public override void StatusTickBehaviour() { }
+
+    public override void DestroyStatus()
+    {
+        _objectRenderer.material.shader = _oldShader;
+        _objectRenderer.material.color = _oldColor;
+        base.DestroyStatus();
+    }
+}

--- a/Assets/Scripts/Status/Utils/TransparentStatus.cs.meta
+++ b/Assets/Scripts/Status/Utils/TransparentStatus.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 50c3c7e75603ffe4fa0ab432328d02ce
+timeCreated: 1507972385
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## New Features
**HighlightStatus**
- Migration from script "MakeGameObjectHighlighted" to HighlightStatus
- Is now a Status that can be used as other buffs/debuffs.
- Will be applied by the GameObjectDetector in the future.
- Hold the old shader when applied and make the parent GameObject Highlighted.
- When finished, re-attribute the old shader to the gameObject.

**TransparentStatus**
- Migration from script "MakeGameObjectTransparent" to TransparentStatus
- Is now a Status that can be used as other buffs/debuffs.
- Will be applied by the GameObjectDetector in the future.
- Hold the old shader when applied and make the parent GameObject Transparent.
- When finished, re-attribute the old shader to the gameObject.

## Enhancement
**StatusBase**
- Now contain a boolean that ensure if a buff is Tickable or not
- By default, buffs are tickable, and will always launch the method StatusTickBehaviour even if it is empty.
- MaxDuration of Status switches from integer to float. 

**EntityLivingBase**
- Now clears every Status present on itself when it dies.

## KB Tasks & PlantUML
- [KB Task #36](https://velandelstudio.com/kanboard/?controller=TaskViewController&action=show&task_id=36&project_id=3)
- [KB Task #103](https://velandelstudio.com/kanboard/?controller=TaskViewController&action=show&task_id=109&project_id=3)
- [KB Task #103](https://velandelstudio.com/kanboard/?controller=TaskViewController&action=show&task_id=109&project_id=3)

_NB : Please note that we are switching to the GitFlow Methodology, this branch is going to be pulled in the Develop Branch and not in the master._
